### PR TITLE
Working

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,0 +1,5 @@
+**/vendor/**/*.js
+**/blueimp/**/*.js
+**/node_modules
+test/public
+test/apos-build

--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,10 @@
 package-lock.json
 *.DS_Store
 node_modules
+/test/node_modules
+/test/public
+/test/apos-build
+/test/data
 
 # Never commit a CSS map file, anywhere
 *.css.map

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,3 @@
 # Changelog
 
-## 1.0.0
+## 1.0.0 Initial release.

--- a/README.md
+++ b/README.md
@@ -36,6 +36,10 @@ Think it over: are you sure you need this module?
 
 ## Installation
 
+**First update `apostrophe` to at least version `3.26.0`.** Prior to that release, there is no need for this module, since ES5 support was formerly included in the core.
+
+Then you can add this module:
+
 ```
 npm install @apostrophecms/asset-es5
 ```

--- a/README.md
+++ b/README.md
@@ -3,49 +3,52 @@
 <div align="center">
   <img src="https://raw.githubusercontent.com/apostrophecms/apostrophe/main/logo.svg" alt="ApostropheCMS logo" width="80" height="80">
 
-  <h1>Apostrophe Module Template</h1>
+  <h1>ES5 Support for ApostropheCMS 3.x</h1>
   <p>
     <a aria-label="Apostrophe logo" href="https://v3.docs.apostrophecms.org">
       <img src="https://img.shields.io/badge/MADE%20FOR%20Apostrophe%203-000000.svg?style=for-the-badge&logo=Apostrophe&labelColor=6516dd">
     </a>
-    <a aria-label="Test status" href="https://github.com/apostrophecms/apostrophe/actions">
-      <img alt="GitHub Workflow Status (branch)" src="https://img.shields.io/github/workflow/status/apostrophecms/apostrophe/Tests/main?label=Tests&labelColor=000000&style=for-the-badge">
+    <a aria-label="Test status" href="https://github.com/apostrophecms/asset-es5/actions">
+      <img alt="GitHub Workflow Status (branch)" src="https://img.shields.io/github/workflow/status/apostrophecms/asset-es5/Tests/main?label=Tests&labelColor=000000&style=for-the-badge">
     </a>
     <a aria-label="Join the community on Discord" href="http://chat.apostrophecms.org">
       <img alt="" src="https://img.shields.io/discord/517772094482677790?color=5865f2&label=Join%20the%20Discord&logo=discord&logoColor=fff&labelColor=000&style=for-the-badge&logoWidth=20">
     </a>
-    <a aria-label="License" href="https://github.com/apostrophecms/module-template/blob/main/LICENSE.md">
+    <a aria-label="License" href="https://github.com/apostrophecms/asset-es5/blob/main/LICENSE.md">
       <img alt="" src="https://img.shields.io/static/v1?style=for-the-badge&labelColor=000000&label=License&message=MIT&color=3DA639">
     </a>
   </p>
 </div>
 
-This module template serves as a starting point for new official Apostrophe modules. This is where you would describe what the purpose of the module is.
+Installing and enabling this module turns on an ES5, Internet Explorer 11-compatible backwards compatibility build for the public-facing frontend JavaScript bundle in Apostrophe 3.x. Modern browsers will still get a modern build and will not pay a performance penalty, although there is a performance impact during development and deployment.
+
+## Limitations
+
+* There is not and never will be support for the admin UI in IE11. This module only addresses the "public" JavaScript (imported by `ui/src/index.js` files).
+
+* This module will polyfill JavaScript language features via `babel`, but doesn't attempt to polyfill missing browser features. You can of course load your own polyfills. Some browser features, like `Observer`, cannot be polyfilled for IE11.
+ 
+* `ui/public` javaScript files are loaded exactly as-is, by design. If you need these to work in IE11, they must already be ES5.
+
+* Using this module will add a lot of `npm install` time, as well as asset build time. IE11 is no longer supported by Microsoft and has most likely been uninstalled automatically from most systems.
+
+Think it over: are you sure you need this module?
 
 ## Installation
 
-To install the module, use the command line to run this command in an Apostrophe project's root directory:
-
 ```
-npm install @apostrophecms/module-template
+npm install @apostrophecms/asset-es5
 ```
 
 ## Usage
 
-Configure the _______ module in the `app.js` file:
+Enable the module in the `app.js` file:
 
 ```javascript
 require('apostrophe')({
   shortName: 'my-project',
   modules: {
-    '@apostrophecms/module-template': {}
+    '@apostrophecms/asset-es5': {}
   }
 });
 ```
-
-### Additional usage sections
-
-### Pre-release checks
-
-- [ ] If the module does not include CSS, remove the Stylelint config file and dependency.
-- [ ] If any template includes a script with inline code, include the `nonce` attribute set like this: `<script nonce="{{ nonce }}">`.

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ npm install @apostrophecms/asset-es5
 
 ## Usage
 
-Enable the module in the `app.js` file:
+Enable this module in the `app.js` file:
 
 ```javascript
 require('apostrophe')({

--- a/i18n/apostrophe/en.json
+++ b/i18n/apostrophe/en.json
@@ -1,0 +1,3 @@
+{
+  "ie11Build": "Public-facing modern JavaScript and Sass (IE11 build)"
+}

--- a/i18n/apostrophe/es.json
+++ b/i18n/apostrophe/es.json
@@ -1,0 +1,3 @@
+{
+  "ie11Build": "JavaScript y Sass (edición IE11) moderno orientado al público"
+}

--- a/i18n/apostrophe/pt-BR.json
+++ b/i18n/apostrophe/pt-BR.json
@@ -1,0 +1,3 @@
+{
+  "ie11Build": "JavaScript and Sass (IE11 build) modernos públicos"
+}

--- a/i18n/apostrophe/sk.json
+++ b/i18n/apostrophe/sk.json
@@ -1,0 +1,3 @@
+{
+  "ie11Build": "Verejný moderný JavaScript a Sass (zostava IE11)"
+}

--- a/index.js
+++ b/index.js
@@ -30,6 +30,6 @@ module.exports = {
           condition: 'nomodule'
         };
       }
-    }
+    };
   }
 };

--- a/index.js
+++ b/index.js
@@ -1,17 +1,35 @@
-const fs = require('fs');
-const path = require('path');
+const es5TaskFn = require('./lib/webpack.es5.js');
+const { stripIndent } = require('common-tags');
 
 module.exports = {
-  bundle: {
-    directory: 'modules',
-    modules: getBundleModuleNames()
+  improve: '@apostrophecms/asset',
+  init(self) {
+    self.es5TaskFn = es5TaskFn;
+  },
+  extendMethods(self) {
+    return {
+      configureBuilds(_super) {
+        _super();
+        self.builds['src-es5'] = {
+          // An alternative build from the same sources for IE11
+          source: 'src',
+          webpack: true,
+          scenes: [ 'public', 'apos' ],
+          // The CSS from the src build is identical, do not duplicate it
+          outputs: [ 'js' ],
+          label: 'apostrophe:ie11Build',
+          // Load index.js and index.scss from each module
+          index: true,
+          // The polyfills babel will be expecting
+          prologue: stripIndent`
+            import "${require.resolve('core-js/stable')}";
+            import "${require.resolve('regenerator-runtime/runtime')}";
+            ${self.srcPrologue}
+          `,
+          // Load only in browsers that do not support ES6 modules
+          condition: 'nomodule'
+        };
+      }
+    }
   }
 };
-
-function getBundleModuleNames() {
-  const source = path.join(__dirname, './modules/@apostrophecms');
-  return fs
-    .readdirSync(source, { withFileTypes: true })
-    .filter(dirent => dirent.isDirectory())
-    .map(dirent => `@apostrophecms/${dirent.name}`);
-}

--- a/lib/webpack.es5.js
+++ b/lib/webpack.es5.js
@@ -1,0 +1,33 @@
+module.exports = (options, apos) => {
+  return {
+    target: [ 'web', 'es5' ],
+    module: {
+      rules: [
+        {
+          test: /\.js$/,
+          exclude: [
+            /\/core-js($|\/)/,
+            /\/regenerator-runtime($|\/)/
+          ],
+          use: [
+            {
+              loader: require.resolve('babel-loader'),
+              options: {
+                presets: [
+                  [
+                    require.resolve('@babel/preset-env'),
+                    {
+                      targets: {
+                        browsers: '> 1%, IE 11, not dead'
+                      }
+                    }
+                  ]
+                ]
+              }
+            }
+          ]
+        }
+      ]
+    }
+  };
+};

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "lint": "npm run eslint",
     "eslint": "eslint .",
-    "test": "npm run lint"
+    "test": "npm run lint && mocha"
   },
   "repository": {
     "type": "git",
@@ -31,7 +31,7 @@
     "eslint-plugin-node": "^11.1.0",
     "eslint-plugin-promise": "^4.2.1",
     "eslint-plugin-standard": "^4.0.1",
-    "stylelint": "^13.7.1",
-    "stylelint-config-apostrophe": "^1.0.0"
+    "apostrophe": "apostrophecms/apostrophe#pro-2932",
+    "mocha": "^10.0.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@apostrophecms/module-template",
+  "name": "@apostrophecms/asset-es5",
   "version": "1.0.0",
   "description": "A template for creating an ApostropheCMS 3 module.",
   "main": "index.js",
@@ -15,6 +15,14 @@
   "homepage": "https://github.com/apostrophecms/module-template#readme",
   "author": "Apostrophe Technologies",
   "license": "MIT",
+  "dependencies": {
+    "@babel/core": "^7.16.7",
+    "@babel/preset-env": "^7.16.7",
+    "babel-loader": "^8.2.5",
+    "common-tags": "^1.8.2",
+    "core-js": "~3.14.0",
+    "regenerator-runtime": "^0.13.7"
+  },
   "devDependencies": {
     "eslint": "^7.9.0",
     "eslint-config-apostrophe": "^3.4.0",

--- a/test/package.json
+++ b/test/package.json
@@ -1,0 +1,6 @@
+{
+  "dependencies": {
+    "apostrophe": "^3.0.0",
+    "@apostrophecms/asset-es5": "^1.0.0"
+  }
+}

--- a/test/test.js
+++ b/test/test.js
@@ -2,6 +2,7 @@
 const testUtil = require('apostrophe/test-lib/test');
 const fs = require('fs');
 const assert = require('assert');
+const cp = require('child_process');
 
 describe('@apostrophecms/asset-es5 module', function () {
   let apos;
@@ -53,12 +54,6 @@ describe('@apostrophecms/asset-es5 module', function () {
 });
 
 function cleanup() {
-  fs.rmSync(`${__dirname}/apos-build`, {
-    recursive: true,
-    force: true
-  });
-  fs.rmSync(`${__dirname}/public/apos-frontend`, {
-    recursive: true,
-    force: true
-  });
+  cp.execSync(`rm -rf ${__dirname}/apos-build`);
+  cp.execSync(`rm -rf ${__dirname}/public/apos-frontend`);
 }

--- a/test/test.js
+++ b/test/test.js
@@ -1,0 +1,64 @@
+/* eslint-disable node/no-path-concat */
+const testUtil = require('apostrophe/test-lib/test');
+const fs = require('fs');
+const assert = require('assert');
+
+describe('@apostrophecms/asset-es5 module', function () {
+  let apos;
+
+  this.timeout(600000);
+
+  after(async function () {
+    testUtil.destroy(apos);
+  });
+
+  // Improving
+  it('should improve the login module', async function () {
+    apos = await testUtil.create({
+      shortname: 'asset-es5',
+      testModule: true,
+      modules: {
+        '@apostrophecms/express': {
+          options: {
+            port: 4242,
+            session: {
+              secret: 'test-this-module'
+            }
+          }
+        },
+        '@apostrophecms/asset-es5': {}
+      }
+    });
+    // Allows development of this module with apostrophe symlinked in,
+    // including webpack path resolution
+    const target = `${__dirname}/../node_modules/apostrophe`;
+    // eslint-disable-next-line node/no-path-concat
+    const link = `${__dirname}/node_modules/apostrophe`;
+    if (fs.existsSync(link)) {
+      fs.unlinkSync(link);
+    }
+    fs.symlinkSync(target, link);
+  });
+
+  it('asset task should build es5 bundle, larger than es6 bundle', async function () {
+    cleanup();
+    process.env.NODE_ENV = 'production';
+    process.env.APOS_RELEASE_ID = 'test';
+    await apos.task.invoke('@apostrophecms/asset:build');
+    const es5Size = fs.statSync(`${__dirname}/public/apos-frontend/releases/test/default/public-nomodule-bundle.js`).size;
+    const es6Size = fs.statSync(`${__dirname}/public/apos-frontend/releases/test/default/public-module-bundle.js`).size;
+    // Make sure there are polyfills in there
+    assert(es5Size > es6Size);
+  });
+});
+
+function cleanup() {
+  fs.rmSync(`${__dirname}/apos-build`, {
+    recursive: true,
+    force: true
+  });
+  fs.rmSync(`${__dirname}/public/apos-frontend`, {
+    recursive: true,
+    force: true
+  });
+}


### PR DESCRIPTION
<!-- Please don't delete this template -->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## Summary

Initial PR

## What are the specific steps to test this change?

Link both this module and the pro-2932 branch of apostrophe into a3-boilerplate and activate this module. `npm run dev` should do an IE11 backwards compatibility build in addition to the regular build (you'll see it in the console output, and page source will show two script tags logged out, one for -modules, one for -nomodules).

Without this module, but with pro-2932 of apostrophe, you should not get an IE11 build, not even with es5: true set for the asset module (you'll get a warning instead).

This module also comes with a simple unit test verifying that an es5 build takes place. I'm intentionally not attempting to port the full power of our old tests for this module which supports a legacy case only. A basic test should be sufficient.

## What kind of change does this PR introduce?
*(Check at least one)*

- [ ] Bug fix
- [X] New feature
- [ ] Refactor
- [X] Documentation
- [ ] Build-related changes
- [ ] Other

## Make sure the PR fulfills these requirements:

- [X] It includes a) the existing issue ID being resolved, b) a convincing reason for adding this feature, or c) a clear description of the bug it resolves
- [ ] The changelog is updated
- [ ] Related documentation has been updated
- [ ] Related tests have been updated

If adding a new feature without an already open issue, it's best to open a **feature request issue** first and wait for approval before working on it.

**Other information:**
